### PR TITLE
Use native-tls instead of rustls for OS trust store support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls", "blocking"] }
 
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }


### PR DESCRIPTION
## Summary

- Switch `reqwest` from `rustls-tls` to `native-tls` so the CLI uses the OS certificate trust store
- Fixes TLS failures in corporate environments with TLS-inspecting proxies (e.g. Zscaler, Netskope)

Fixes #7

## Context

`rustls` bundles its own webpki root certificates and ignores the system trust store. In corporate environments where a proxy performs TLS inspection, the proxy's CA is trusted by the OS but not by rustls, causing `invalid peer certificate: UnknownIssuer` errors.

`native-tls` delegates to the platform's TLS implementation (Security.framework on macOS, SChannel on Windows, OpenSSL on Linux), which respects the system trust store.

## Test plan

- [ ] Verify `models list providers` works in a standard environment
- [ ] Verify it works behind a TLS-inspecting corporate proxy