### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,21 +2,83 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Being respectful of differing viewpoints
-* Accepting constructive criticism gracefully
-* Focusing on what is best for the community
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive behavior may be reported to the community leaders.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ari111097@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,71 @@
 # Contributing
 
-Thanks for contributing to `models`.
+Thanks for your interest in contributing to `models`! This guide will help you get started.
 
-## Quick Start
-- Fork the repository
-- Create a branch from `main`
-- Keep changes focused and minimal
-- Open a PR with clear context
+## Prerequisites
 
-## Local Checks
-- Run existing project checks before submitting
-- Include notes on what you validated
+- [Rust](https://www.rust-lang.org/tools/install) (stable) — install via [rustup](https://rustup.rs/)
+- [mise](https://mise.jdx.dev/) (optional, recommended) — task runner that wraps cargo commands
+- Git
 
-## Issues
-Please include reproduction steps, expected behavior, and environment details.
+## Getting Started
+
+```bash
+git clone https://github.com/arimxyer/models
+cd models
+cargo build
+cargo run
+```
+
+If you have mise installed, `mise run build` and `mise run run` work as well.
+
+## Running Checks
+
+Run these before every PR:
+
+```bash
+# With mise
+mise run fmt && mise run clippy && mise run test
+
+# Without mise
+cargo fmt && cargo clippy -- -D warnings && cargo test
+```
+
+All three must pass. CI enforces the same checks on pull requests.
+
+## Code Conventions
+
+- **Clippy** runs with `-D warnings` — all warnings are errors
+- **No `eprintln!` in TUI code** — stderr output corrupts ratatui's alternate screen buffer. Use `Message` variants or status bar updates instead. (`eprintln!` is fine in CLI-only code paths.)
+- **Enum-based message passing** — the TUI uses an Elm-architecture pattern with a `Message` enum. No callbacks.
+- **New `BenchmarkEntry` fields** must use `#[serde(default)]`
+- **Commit `Cargo.lock`** alongside `Cargo.toml` when changing dependencies or version
+
+## Data Directory
+
+- **`data/agents.json`** — curated catalog of AI coding agents. Contributions welcome! Adding a new agent here requires no Rust knowledge or build tools.
+- **`data/benchmarks.json`** — auto-generated from the Artificial Analysis API every 30 minutes. Do not edit manually.
+
+See [Custom Agents](docs/custom-agents.md) for the agent entry format.
+
+## Architecture
+
+For detailed architecture documentation, key file locations, async patterns, and gotchas, see [CLAUDE.md](CLAUDE.md).
+
+## Pull Requests
+
+- Branch from `main` and keep changes focused
+- Reference related issues in your PR description
+- CI runs format checking, clippy, and tests on every PR (doc-only changes are skipped)
+
+## Reporting Issues
+
+When opening an issue, please include:
+
+- Steps to reproduce the problem
+- Expected vs actual behavior
+- Your environment (OS, terminal, Rust version)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/README.md
+++ b/README.md
@@ -368,11 +368,17 @@ models search "llama" --json
 
 ## Data Sources
 
-Lots of gratitude and couldn't have made this application without these workhorses doing the legwork. Shout out to the sources!:
+Lots of gratitude to the companies who do all the hard work! Shout out to the sources:
 - **Model data**: Fetched from [models.dev](https://models.dev), an open-source database of AI models maintained by [SST](https://github.com/sst/models.dev)
 - **Benchmark data**: Fetched from [Artificial Analysis](https://artificialanalysis.ai) — quality indexes, benchmark scores, speed, and pricing for ~400 model entries
 - **Agent data**: Curated catalog in [`data/agents.json`](data/agents.json) — contributions welcome!
 - **GitHub data**: Fetched from GitHub API (stars, releases, changelogs)
+
+## Contributing
+
+Contributions are welcome! Please read the [Contributing Guide](CONTRIBUTING.md) before submitting a PR.
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
Add a contributor code of conduct based on the Contributor Covenant to establish community standards.