### PR TITLE
Prod readiness: fix clippy lint, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ TUI and CLI for browsing AI models, benchmarks, and coding agents.
 - **Models Tab**: Browse 3,000+ models across 85+ providers from [models.dev](https://models.dev) with capability indicators, adaptive layouts, and provider categorization
 - **Benchmarks Tab**: Compare model performance across 15+ benchmarks from [Artificial Analysis](https://artificialanalysis.ai), with head-to-head tables, scatter plots, radar charts, and creator filtering
 - **Agents Tab**: Track AI coding assistants (Claude Code, Aider, Cursor, etc.) with version detection, changelogs, and GitHub integration
+- **Status Tab**: Monitor provider health with live incident tracking and scheduled maintenance across 21+ providers
 
 <video src="https://github.com/user-attachments/assets/07c750f4-ca47-4f89-8a32-99e0be5004d8" controls width="100%"></video>
 > **Video (and screenshots below) are out-of-sync with the current state of the app, I've been moving fast on making changes and so I'll have to record a new one!**
 
 ## What's New
 
+- **Status tab** — live provider health monitoring with incidents, maintenance, and grouped services for 21+ providers
+- **Scrollable detail panels** — Models and Benchmarks detail panels are now navigable and scrollable
 - **Models tab redesign** — capability indicators, adaptive provider panel, and detailed model info at a glance
 - **Benchmark compare mode** — head-to-head tables, scatter plots, and radar charts for selected models
 - **Benchmarks CLI** — list and inspect benchmark data directly from the terminal
@@ -49,6 +52,13 @@ TUI and CLI for browsing AI models, benchmarks, and coding agents.
 - **Creator sidebar** with 40+ creators — filter by region, type, or open/closed source
 - **Sort & filter** — sort by any metric, filter by reasoning capability, source type, and more
 - **Detail panel** — full benchmark breakdown with indexes, scores, performance, and pricing
+
+### Status Tab
+- **Live provider health** — monitor 21+ AI providers across 7 status page platforms
+- **Health indicators** — operational (●), degraded (◐), outage (✗), maintenance (◆)
+- **Overall dashboard** — health gauge, incident and maintenance cards at a glance
+- **Provider detail** — grouped services, incidents, and scheduled maintenance
+- **Multi-source** — unified status from Statuspage, BetterStack, Instatus, incident.io, and more
 
 ### Agents CLI
 - **Status table** — see installed vs latest version, 24h release indicator, and release frequency at a glance
@@ -148,7 +158,7 @@ models
 **Global**
 | Key | Action |
 |-----|--------|
-| `]` / `[` | Switch tabs (Models / Agents / Benchmarks) |
+| `]` / `[` | Switch tabs (Models / Agents / Benchmarks / Status) |
 | `?` | Show context-aware help |
 | `q` | Quit |
 
@@ -282,6 +292,16 @@ See [Custom Agents](docs/custom-agents.md) for the full reference.
 | Key | Action |
 |-----|--------|
 | `o` | Open Artificial Analysis page |
+
+### Status Tab
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `h` / `l` | Switch focus (List ↔ Detail) |
+| `h` / `l` | Cycle detail sub-panels (Services / Incidents / Maintenance) |
+| `o` | Open provider status page |
+| `r` | Refresh provider status |
+| `/` | Search providers |
 
 ---
 

--- a/src/cli/benchmarks.rs
+++ b/src/cli/benchmarks.rs
@@ -1414,11 +1414,11 @@ mod tests {
 
     #[test]
     fn ambiguous_matches_message_lists_candidate_slugs() {
-        let entries = vec![
+        let entries = [
             make_entry("alpha", "Alpha", "openai", "OpenAI", Some(90.0)),
             make_entry("beta", "Beta", "openai", "OpenAI", Some(80.0)),
         ];
-        let matches = vec![&entries[0], &entries[1]];
+        let matches = [&entries[0], &entries[1]];
 
         let message = ambiguous_matches_message("a", &matches);
         assert!(message.contains("ambiguous"));
@@ -1428,7 +1428,7 @@ mod tests {
 
     #[test]
     fn filter_picker_entries_applies_live_query() {
-        let entries = vec![
+        let entries = [
             make_entry(
                 "claude-opus",
                 "Claude Opus",
@@ -1453,7 +1453,7 @@ mod tests {
 
     #[test]
     fn filter_picker_entries_resorts_by_requested_metric() {
-        let entries = vec![
+        let entries = [
             make_entry("alpha", "Alpha", "openai", "OpenAI", Some(80.0)),
             make_entry("beta", "Beta", "openai", "OpenAI", Some(90.0)),
         ];

--- a/src/tui/CLAUDE.md
+++ b/src/tui/CLAUDE.md
@@ -8,15 +8,15 @@ The TUI uses per-tab subdirectories, each containing app state and rendering:
 tui/
 ├── models/
 │   ├── mod.rs     (pub use app::*)
-│   ├── app.rs     (ModelsApp state, Focus, Filters, SortOrder)
-│   └── render.rs  (draw_main)
+│   ├── app.rs     (ModelsApp state, Focus with Details, detail_scroll, Filters, SortOrder)
+│   └── render.rs  (draw_main, model_detail_lines, ScrollablePanel detail)
 ├── agents/
 │   ├── mod.rs     (pub use app::*)
 │   ├── app.rs     (AgentsApp state, AgentFocus, AgentSortOrder)
 │   └── render.rs  (draw_agents_main, draw_picker_modal)
 ├── benchmarks/
 │   ├── mod.rs     (pub use app::*)
-│   ├── app.rs     (BenchmarksApp state, BenchmarkFocus, BottomView, ScatterAxis, RadarPreset)
+│   ├── app.rs     (BenchmarksApp state, BenchmarkFocus with Details, detail_scroll, BottomView, ScatterAxis, RadarPreset)
 │   ├── render.rs  (draw_benchmarks_main, compare_colors)
 │   ├── compare.rs (draw_h2h_table_generic, draw_scatter)
 │   └── radar.rs   (draw_radar, spoke_angles, polygon_vertices, axes_for_preset)

--- a/src/tui/benchmarks/CLAUDE.md
+++ b/src/tui/benchmarks/CLAUDE.md
@@ -1,7 +1,7 @@
 # Benchmarks Tab
 
 ## Files
-- `app.rs` — `BenchmarksApp` state, `BenchmarkFocus` (Creators/List/Compare), `BottomView` (Detail/H2H/Scatter/Radar), `ScatterAxis`, `RadarPreset`, sort/filter types
+- `app.rs` — `BenchmarksApp` state, `BenchmarkFocus` (Creators/List/Details/Compare), `BottomView` (Detail/H2H/Scatter/Radar), `ScatterAxis`, `RadarPreset`, `detail_scroll: ScrollOffset`, sort/filter types
 - `render.rs` — `draw_benchmarks_main()`, `compare_colors()` (8-color palette for multi-select)
 - `compare.rs` — `draw_h2h_table_generic()`, `draw_scatter()` (comparison visualizations)
 - `radar.rs` — `draw_radar()`, spoke angle math, polygon vertex calculation, preset axis definitions
@@ -12,3 +12,6 @@
 - `compare_colors()` returns 8 colors indexed modulo — used by H2H columns, scatter points, radar polygons, and legend
 - `RadarPreset` defines axis groups (Overall, Coding, Math, Reasoning) — each preset maps to 5-6 benchmark fields
 - Scatter axis selection cycles through benchmark metrics via `ScatterAxis::next()`
+- Detail panel uses `ScrollablePanel` widget with `detail_scroll: ScrollOffset` for scrollable, focus-aware rendering
+- Browse mode focus navigation uses directional `focus_left()`/`focus_right()` cycling through Creators → List → Details
+- `reset_detail_scroll()` called on every benchmark selection change (navigation, filter, sort, rebuild)

--- a/src/tui/models/CLAUDE.md
+++ b/src/tui/models/CLAUDE.md
@@ -1,7 +1,7 @@
 # Models Tab
 
 ## Files
-- `app.rs` — `ModelsApp` state, `Focus` (Providers/Models), `SortOrder`, `Filters`, `ProviderListItem`, `ModelEntry`
+- `app.rs` — `ModelsApp` state, `Focus` (Providers/Models/Details), `SortOrder`, `Filters`, `ProviderListItem`, `ModelEntry`, `detail_scroll: ScrollOffset`
 - `render.rs` — `draw_main()` renders the 3-column layout (providers | model list | detail panel)
 
 ## Key Patterns
@@ -9,3 +9,6 @@
 - `model_list_state` uses `select(Some(idx + 1))` offset because row 0 is the column header
 - `ProviderListItem::CategoryHeader` items are non-selectable — `find_selectable_index()` skips them
 - Sort/filter methods (`cycle_sort`, `toggle_reasoning`, etc.) live on `ModelsApp` and call `update_filtered_models` internally
+- Detail panel uses `ScrollablePanel` widget with `detail_scroll: ScrollOffset` for scrollable, focus-aware rendering
+- Focus navigation uses directional `focus_left()`/`focus_right()` cycling through Providers → Models → Details
+- `reset_detail_scroll()` called on every model selection change (navigation, sort, filter, search)


### PR DESCRIPTION
## Summary
- Fix 3 clippy `useless_vec` lint violations in `src/cli/benchmarks.rs` test code (array literals instead of `vec![]`)
- Add **Status tab** to README: feature description, keybindings section, What's New entry
- Add **scrollable detail panels** mention to README What's New
- Update CLAUDE.md files for Models, Benchmarks, and TUI modules to reflect `Focus::Details`, `BenchmarkFocus::Details`, `detail_scroll`, and directional focus methods

## Test plan
- [x] `mise run fmt` passes
- [x] `mise run clippy` passes (fixes the blocking lint)
- [x] All 256 tests pass
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)