### PR TITLE
Update docs for PR #24 changes

### DIFF
--- a/.claude/rules/tui-style-guide.md
+++ b/.claude/rules/tui-style-guide.md
@@ -29,7 +29,8 @@ The header and footer are rendered by `draw_header()` and `draw_footer()` — ta
 | Role | Color | Usage |
 |------|-------|-------|
 | **Focus / Active** | `Color::Cyan` | Focused borders, active tab text, section headers, URLs, interactive highlights |
-| **Inactive / Secondary** | `Color::DarkGray` | Unfocused borders, labels, secondary text, inactive filters, missing data placeholders |
+| **Inactive / Secondary** | `Color::DarkGray` | Unfocused borders, secondary text, inactive filters, missing data placeholders |
+| **Labels / Secondary text** | `Color::Gray` | Detail panel label text (e.g., "Provider:", "Installed:", "Latest release:") |
 | **Selected / Hint** | `Color::Yellow` | Selected item text, keybinding hints in footer/help, sort indicators, warnings, loading text |
 | **Positive / Open** | `Color::Green` | Operational status, open weights, "All" items, active filter keys, "up to date", free pricing |
 | **Negative / Closed** | `Color::Red` | Errors, outages, closed weights, deprecated status, fetch failures |
@@ -91,7 +92,7 @@ The header and footer are rendered by `draw_header()` and `draw_footer()` — ta
 ### 3.2 Label/Value Pattern
 
 Detail panels consistently use:
-- **Labels:** `Style::default().fg(Color::DarkGray)` (e.g., "Provider:", "Installed:", "Latest release:")
+- **Labels:** `Style::default().fg(Color::Gray)` (e.g., "Provider:", "Installed:", "Latest release:")
 - **Values:** `Style::default().fg(Color::White)` (or `Color::DarkGray` if deprecated/unavailable)
 - **Missing values:** em-dash `\u{2014}` in `Color::DarkGray`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Each module has its own `CLAUDE.md` with detailed documentation. Top-level highl
 - `src/benchmarks/` — `store.rs` (BenchmarkStore/Entry), `fetch.rs` (CDN fetcher), `traits.rs` (AA↔models.dev matching)
 - `src/status/` — `types.rs`, `registry.rs`, `assessment.rs`, `fetch.rs`, `adapters/` (per-source-family parsers)
 - `src/tui/` — `app.rs` (App state, Message enum), `event.rs` (NavAction dedup), `ui.rs` (shared helpers), `markdown.rs`, `widgets/` (ScrollablePanel, SoftCard, ScrollOffset, ComparisonLegend), per-tab subdirs: `models/`, `agents/`, `benchmarks/` (includes `radar.rs`), `status/` — each with `app.rs` (sub-app state) + `render.rs` (tab rendering)
+- `src/agents/health.rs` — agent-to-status-provider mapping for service health display in the Agents tab
 - `src/cli/` — `picker.rs` (shared PickerTerminal, nav helpers, style constants), `models.rs`/`benchmarks.rs`/`agents_ui.rs` (inline pickers), `styles.rs`
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ TUI and CLI for browsing AI models, benchmarks, and coding agents.
 - **Overall dashboard** — health gauge, incident and maintenance cards at a glance
 - **Provider detail** — grouped services, incidents, and scheduled maintenance
 - **Multi-source** — unified status from Statuspage, BetterStack, Instatus, incident.io, and more
+- **Customizable tracking** — choose which providers to monitor (press `a` to open the tracking picker)
 
 ### Agents CLI
 - **Status table** — see installed vs latest version, 24h release indicator, and release frequency at a glance
@@ -299,6 +300,7 @@ See [Custom Agents](docs/custom-agents.md) for the full reference.
 |-----|--------|
 | `Tab` / `h` / `l` | Switch focus (List ↔ Detail) |
 | `h` / `l` | Cycle detail sub-panels (Services / Incidents / Maintenance) |
+| `a` | Add/remove tracked providers |
 | `o` | Open provider status page |
 | `r` | Refresh provider status |
 | `/` | Search providers |

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -4,7 +4,7 @@
 
 | Directory | Purpose | CLAUDE.md |
 |-----------|---------|-----------|
-| `agents/` | Agent data, GitHub integration, caching, changelog parsing | Yes |
+| `agents/` | Agent data, GitHub integration, caching, changelog parsing, agent-to-status-provider mapping (`health.rs`) | Yes |
 | `benchmarks/` | Benchmark store, CDN fetching, models.dev trait matching | Yes |
 | `cli/` | Subcommands, inline pickers, shared picker infrastructure | Yes |
 | `status/` | Provider health types, registry, assessment, fetch adapters | Yes |

--- a/src/agents/CLAUDE.md
+++ b/src/agents/CLAUDE.md
@@ -12,6 +12,8 @@ Tracks AI coding assistants (CLI tools, IDEs, plugins) with GitHub metadata, loc
 | `AgentEntry` | `data.rs` | Combined entry: Agent + GitHubData + InstalledInfo + tracked flag. Methods: `update_available()`, `new_releases()`, `latest_release_relative_time()` |
 | `ChangelogBlock` | `changelog_parser.rs` | Normalized IR: `Heading(String)` \| `Bullet(String)` \| `Paragraph(String)`. Used by both CLI (`agents.rs`) and TUI preview panes |
 | `Changelog` | `changelog_parser.rs` | Flat list of ChangelogBlock. Produced by `parse_changelog()` (comrak AST → IR) |
+| `AgentServiceMapping` | `health.rs` | Maps agent IDs to status provider slugs and component names for service health display |
+| `ResolvedHealth` | `health.rs` | Resolved health with provider name and optional component name |
 
 ## Data Flow
 

--- a/src/cli/CLAUDE.md
+++ b/src/cli/CLAUDE.md
@@ -32,7 +32,7 @@ All 3 pickers (models, benchmarks, agents) follow the same lifecycle:
 - `models search <query>` — keyword match, interactive picker for selection
 - `models show <name>` — single-model detail view with benchmarks/capabilities
 - `models benchmarks` — interactive picker, can output JSON via --json
-- `agents status|latest|list-sources` — table output
+- `agents status|latest|list-sources` — table output; `agents status` sorts by most recently updated and includes a "Status" column with service health icons
 - `agents <tool>` — release browser with changelog search (agents_ui.rs)
 
 Tool-specific flags parsed manually in `ToolArgs::parse_from()` (not clap, since tools are `external_subcommand`).

--- a/src/tui/CLAUDE.md
+++ b/src/tui/CLAUDE.md
@@ -87,3 +87,4 @@ tui/
 - Borrow checker in render: extract values before `Paragraph::new()` consumes them; defer mutable updates after.
 - `LazyLock` for compiled regex singletons in `markdown.rs`.
 - Async fetches use tokio::spawn + mpsc channels. Results arrive as `Message` variants in the main loop — app never blocks.
+- `StatusApp::new()` takes `&Config` (not `&AgentsFile`) — status tab is independent of agents data loading and can be constructed without agent data.

--- a/src/tui/agents/CLAUDE.md
+++ b/src/tui/agents/CLAUDE.md
@@ -9,3 +9,4 @@
 - Changelog search with `n`/`N` match navigation uses `search_matches: Vec<usize>` (line indices into rendered markdown)
 - Detail scroll uses `detail_scroll: u16` — counts visual wrapped lines, not logical lines
 - Source picker modal intercepts global keys (especially `q`) to prevent accidental quit
+- Service health display: agents with status provider mappings show health icon + label in detail panel via `resolve_agent_service_health()`

--- a/src/tui/models/CLAUDE.md
+++ b/src/tui/models/CLAUDE.md
@@ -12,3 +12,4 @@
 - Detail panel uses `ScrollablePanel` widget with `detail_scroll: ScrollOffset` for scrollable, focus-aware rendering
 - Focus navigation uses directional `focus_left()`/`focus_right()` cycling through Providers → Models → Details
 - `reset_detail_scroll()` called on every model selection change (navigation, sort, filter, search)
+- Provider list items display a category initial prefix (O/C/I/G/T for Origin/Cloud/Inference/Gateway/Tool) at the start of each item instead of an abbreviated label at the end

--- a/src/tui/status/CLAUDE.md
+++ b/src/tui/status/CLAUDE.md
@@ -8,6 +8,11 @@
 
 ## Key Patterns
 - `StatusApp` is `Option<StatusApp>` on `App` — constructed when status data first arrives
+- `StatusApp::new(&Config)` takes a `&Config` reference (not `&AgentsFile`) — status tab is independent of agents data loading
+- `tracked: HashSet<String>` field on `StatusApp` holds the set of provider slugs to display — providers not in this set are hidden by `update_filtered()`
+- `show_picker: bool` and associated picker state on `StatusApp` control the provider tracking modal (press `a` to open)
+- `apply_fetch()` merges incoming provider status by slug (not full replacement) — existing entries are updated in place, new slugs are inserted
+- `update_filtered()` rebuilds the visible provider list, hiding untracked providers (those whose slug is not in `tracked`)
 - Overall view: gauge + icon+count legend + 3 SoftCard panels (incidents, degradation, maintenance)
 - Provider detail view: gauge header with icon legend, grouped services panel, incidents + maintenance (horizontal when wide)
 - `OverallPanelFocus` cycles through overall panels, `DetailPanelFocus` cycles through detail panels — both via h/l


### PR DESCRIPTION
## Summary

- Update `tui-style-guide.md` to use `Color::Gray` for labels (not `Color::DarkGray`) and add Gray to the semantic color table
- Expand `src/tui/status/CLAUDE.md` with `StatusApp::new(&Config)`, `tracked` field, `show_picker`, `apply_fetch()` merge behavior, and `update_filtered()` semantics
- Add `AgentServiceMapping` and `ResolvedHealth` types from `health.rs` to `src/agents/CLAUDE.md` key types table
- Note `health.rs` in `src/CLAUDE.md` module map for `agents/`
- Add service health display pattern to `src/tui/agents/CLAUDE.md`
- Add category initial prefix pattern to `src/tui/models/CLAUDE.md`
- Update `src/cli/CLAUDE.md` to note `agents status` sort order and Status column
- Add customizable tracking feature and `a` keybinding to `README.md` Status Tab section
- Add `src/agents/health.rs` to key files in root `CLAUDE.md`
- Add `StatusApp::new()` signature gotcha to `src/tui/CLAUDE.md`

## Test plan

- [x] `mise run fmt` — no changes
- [x] `mise run clippy` — clean (0 warnings)
- [x] `mise run test` — 264 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)