### PR TITLE
Fix help text alignment, remove --pick flag and Aider agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "modelsdev"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsdev"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "A fast TUI and CLI for browsing AI models, benchmarks, and coding agents"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 TUI and CLI for browsing AI models, benchmarks, coding agents, and statuses for AI providers. 
 
 - **Models Tab**: Browse 3,000+ models across 85+ providers from [models.dev](https://models.dev) with capability indicators, adaptive layouts, and provider categorization
-- **Agents Tab**: Track AI coding assistants (Claude Code, Aider, Cursor, etc.) with version detection, changelogs, and GitHub integration
+- **Agents Tab**: Track AI coding assistants (Claude Code, Cursor, Codex, etc.) with version detection, changelogs, and GitHub integration
 - **Benchmarks Tab**: Compare model performance across 15+ benchmarks from [Artificial Analysis](https://artificialanalysis.ai), with head-to-head tables, scatter plots, radar charts, and creator filtering
 - **Status Tab**: Monitor provider health with live incident tracking and scheduled maintenance across 21+ providers
 
@@ -412,7 +412,6 @@ agents claude --version 1.0.170  # Specific version
 
 ```bash
 agents claude --list       # List all versions
-agents claude --pick       # Alias for the interactive release browser
 ```
 
 In the release browser:
@@ -450,6 +449,14 @@ Once the picker is open:
 ```bash
 models providers
 models providers --json
+```
+
+#### Shell Completions
+
+```bash
+models completions bash
+models completions fish
+models completions zsh
 ```
 
 #### Show model details

--- a/data/agents.json
+++ b/data/agents.json
@@ -23,26 +23,6 @@
       "homepage": "https://claude.ai/code",
       "docs": "https://docs.anthropic.com/en/docs/claude-code"
     },
-    "aider": {
-      "name": "Aider",
-      "repo": "paul-gauthier/aider",
-      "categories": ["cli"],
-      "installation_method": "cli",
-      "pricing": {
-        "model": "free",
-        "free_tier": true,
-        "usage_notes": "Free tool, pay for underlying model API"
-      },
-      "supported_providers": ["openai", "anthropic", "openrouter", "ollama"],
-      "platform_support": ["macos", "linux", "windows"],
-      "open_source": true,
-      "cli_binary": "aider",
-      "version_command": ["--version"],
-      "version_regex": "aider v([0-9]+\\.[0-9]+\\.[0-9]+)",
-      "config_files": ["~/.aider.conf.yml", ".aider.conf.yml"],
-      "homepage": "https://aider.chat",
-      "docs": "https://aider.chat/docs"
-    },
     "cursor": {
       "name": "Cursor",
       "repo": "getcursor/cursor",

--- a/src/agents/detect.rs
+++ b/src/agents/detect.rs
@@ -116,7 +116,7 @@ mod tests {
             Some("1.0.30".to_string())
         );
         assert_eq!(
-            extract_version("aider v0.82.1", None),
+            extract_version("opencode v0.82.1", None),
             Some("0.82.1".to_string())
         );
         assert_eq!(

--- a/src/agents/health.rs
+++ b/src/agents/health.rs
@@ -116,13 +116,12 @@ mod tests {
 
     #[test]
     fn unmapped_agents_return_none() {
-        assert!(service_mapping_for_agent("aider").is_none());
         assert!(service_mapping_for_agent("opencode").is_none());
     }
 
     #[test]
     fn resolve_returns_none_for_unmapped() {
-        assert!(resolve_agent_service_health("aider", &[]).is_none());
+        assert!(resolve_agent_service_health("opencode", &[]).is_none());
     }
 
     #[test]

--- a/src/agents/loader.rs
+++ b/src/agents/loader.rs
@@ -27,6 +27,6 @@ mod tests {
         assert!(agents.schema_version >= 1);
         assert!(!agents.agents.is_empty());
         assert!(agents.agents.contains_key("claude-code"));
-        assert!(agents.agents.contains_key("aider"));
+        assert!(agents.agents.contains_key("cursor"));
     }
 }

--- a/src/cli/CLAUDE.md
+++ b/src/cli/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLI Module — Architecture & Patterns
 
 ## Module Purpose
-Subcommands for models, benchmarks, agents: thin clap wrappers (`list.rs`, `search.rs`, `show.rs`, `benchmarks.rs`) that delegate to interactive pickers or direct output. Binary aliases support `models <cmd>` and `agents <cmd>` (detected via argv[0]).
+Subcommands for models, benchmarks, agents: thin clap wrappers (`list.rs`, `search.rs`, `show.rs`, `benchmarks.rs`) that delegate to interactive pickers or direct output. Binary aliases support `models <cmd>`, `agents <cmd>`, and `benchmarks <cmd>` (detected via argv[0]).
 
 ## Shared Picker Infrastructure (`picker.rs`)
 
@@ -31,6 +31,8 @@ All 3 pickers (models, benchmarks, agents) follow the same lifecycle:
 - `models list` — filters + sort, delegates to picker or table output
 - `models search <query>` — keyword match, interactive picker for selection
 - `models show <name>` — single-model detail view with benchmarks/capabilities
+- `models providers` — list all providers, supports --json
+- `models completions <shell>` — generate shell completions (bash/fish/zsh/elvish/powershell)
 - `models benchmarks` — interactive picker, can output JSON via --json
 - `agents status|latest|list-sources` — table output; `agents status` sorts by most recently updated and includes a "Status" column with service health icons
 - `agents <tool>` — release browser with changelog search (agents_ui.rs)

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -12,7 +12,6 @@ use tokio::sync::RwLock;
   agents <tool>                 Browse releases for a tool
   agents <tool> --latest        Show latest changelog directly
   agents <tool> --list, -l      List all versions
-  agents <tool> --pick, -p      Alias for the interactive release browser
   agents <tool> --version <v>   Show changelog for a specific version
   agents <tool> --web, -w       Open releases page in browser
 
@@ -20,7 +19,7 @@ use tokio::sync::RwLock;
   agents claude                 Browse Claude Code releases
   agents claude --latest        Latest Claude Code changelog
   agents cursor --list          All Cursor versions
-  agents aider --pick           Open the interactive release browser")]
+  agents cursor --version 1.0.0 Show a specific Cursor version")]
 pub struct AgentsCli {
     #[command(subcommand)]
     pub command: Option<AgentsCommand>,
@@ -45,7 +44,6 @@ pub struct ToolArgs {
     pub tool: String,
     pub latest: bool,
     pub list: bool,
-    pub pick: bool,
     pub version: Option<String>,
     pub web: bool,
 }
@@ -58,7 +56,6 @@ impl ToolArgs {
         let tool = args[0].clone();
         let mut latest = false;
         let mut list = false;
-        let mut pick = false;
         let mut version = None;
         let mut web = false;
 
@@ -67,7 +64,6 @@ impl ToolArgs {
             match args[i].as_str() {
                 "--latest" => latest = true,
                 "--list" | "-l" => list = true,
-                "--pick" | "-p" => pick = true,
                 "--web" | "-w" => web = true,
                 "--version" => {
                     i += 1;
@@ -83,19 +79,18 @@ impl ToolArgs {
         }
 
         // Mutual exclusivity
-        let mode_count = [latest, list, pick, version.is_some()]
+        let mode_count = [latest, list, version.is_some()]
             .iter()
             .filter(|&&v| v)
             .count();
         if mode_count > 1 {
-            anyhow::bail!("--latest, --list, --pick, and --version are mutually exclusive");
+            anyhow::bail!("--latest, --list, and --version are mutually exclusive");
         }
 
         Ok(Self {
             tool,
             latest,
             list,
-            pick,
             version,
             web,
         })
@@ -786,10 +781,6 @@ fn run_tool(args: ToolArgs) -> Result<()> {
         return run_version_list(&entry.agent, &github);
     }
 
-    if args.pick {
-        return run_release_browser(&entry, &github);
-    }
-
     if args.latest {
         return print_specific_or_latest_release(&entry.agent.name, &github, None);
     }
@@ -1146,16 +1137,15 @@ mod tests {
         assert_eq!(parsed.tool, "claude");
         assert!(parsed.latest);
         assert!(!parsed.list);
-        assert!(!parsed.pick);
         assert!(parsed.version.is_none());
     }
 
     #[test]
-    fn tool_args_rejects_conflicting_latest_and_pick() {
+    fn tool_args_rejects_conflicting_latest_and_list() {
         let err = ToolArgs::parse_from(vec![
             "claude".to_string(),
             "--latest".to_string(),
-            "--pick".to_string(),
+            "--list".to_string(),
         ])
         .unwrap_err()
         .to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,7 +221,6 @@ mod tests {
         assert!(config.is_tracked("claude-code"));
         assert!(config.is_tracked("codex"));
         // Not in default list
-        assert!(!config.is_tracked("aider"));
         assert!(!config.is_tracked("cursor"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,6 @@ enum Commands {
   agents <tool>                 Browse releases for a tool
   agents <tool> --latest        Show latest changelog directly
   agents <tool> --list, -l      List all versions
-  agents <tool> --pick, -p      Alias for the interactive release browser
   agents <tool> --version <v>   Show changelog for a specific version
   agents <tool> --web, -w       Open releases page in browser
 
@@ -89,7 +88,7 @@ enum Commands {
   agents claude                 Browse Claude Code releases
   agents claude --latest        Latest Claude Code changelog
   agents cursor --list          All Cursor versions
-  agents aider --pick           Pick an Aider release interactively")]
+  agents cursor --version 1.0.0 Show a specific Cursor version")]
     Agents {
         #[command(subcommand)]
         command: Option<cli::agents::AgentsCommand>,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -511,6 +511,10 @@ fn draw_help_popup(f: &mut Frame, scroll: &ScrollOffset, current_tab: Tab) {
                 help_line("c", "Copy agent name"),
                 help_line("a", "Add/remove tracked agents"),
                 Line::from(""),
+                help_section("Search Navigation"),
+                help_line("n", "Next search match"),
+                help_line("N", "Previous search match"),
+                Line::from(""),
                 help_section("Status Indicators"),
                 Line::from(vec![
                     Span::styled(
@@ -582,7 +586,6 @@ fn draw_help_popup(f: &mut Frame, scroll: &ScrollOffset, current_tab: Tab) {
                 help_section("Status view"),
                 help_line("Tab/h/l", "Switch list/details focus"),
                 help_line("/", "Search providers"),
-                help_line("e", "Expand/collapse services"),
                 Line::from(""),
             ]);
         }


### PR DESCRIPTION
## Summary
- Remove phantom `e` key from Status tab help popup (documented but never implemented)
- Add `n`/`N` search match navigation to Agents tab help (working but undocumented)
- Remove redundant `--pick`/`-p` flag from agents CLI (default TTY behavior already opens the interactive browser)
- Remove Aider from agent catalog, help text, README, and tests
- Add Shell Completions section to README and update CLI CLAUDE.md
- Bump version to 0.11.2

## Test plan
- [x] `mise run fmt && mise run clippy && mise run test` — all 264 tests pass
- [ ] Run TUI, press `?` on each tab — verify help content matches actual keybindings
- [ ] Run `models completions fish` — confirm command works
- [ ] Run `agents claude` — verify no `--pick` references in help output
- [ ] Verify Aider no longer appears in `agents status` or `agents list-sources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)