### PR TITLE
docs: Add documentation comment to app module

### DIFF
--- a/src/tui/agents/mod.rs
+++ b/src/tui/agents/mod.rs
@@ -1,3 +1,4 @@
+/// Application module for the TUI, containing the main application logic and UI components.
 pub mod app;
 pub(in crate::tui) mod render;
 


### PR DESCRIPTION
### 问题背景
在 `src/tui/agents/mod.rs` 中，公共模块 `app` 缺少文档注释，这不符合 Rust 项目的文档最佳实践，降低了代码的可读性和可维护性。

### 修改内容
- 在 `pub mod app;` 前添加了文档注释，说明该模块是 TUI 的应用程序模块，包含主要应用逻辑和 UI 组件。
- 原因：提供清晰的文档有助于开发者快速理解模块的作用，提高代码质量和协作效率。
- 提升：增强了代码的文档覆盖，符合 Rust 社区推荐的文档标准，从而提升了整体代码质量。

### 验证方式
- 此修改仅添加文档注释，不影响代码功能，因此所有现有测试应继续通过。
- 没有添加新测试，因为这是文档改进。
- 手动验证：运行 `cargo test` 确保编译和测试通过，并检查生成的文档（如 `cargo doc`）是否正确显示注释。

### 其他信息
- 没有 breaking changes。
- 此 PR 直接更新了模块文档，无需额外文档更新。
- 无已知限制。