### PR TITLE
ci: replace GitHub Actions cache with Cachix binary cache

### DIFF
--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -24,11 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Magic Nix Cache authenticates to GitHub's cache service with OIDC, so the
-# workflow needs the minimal read + ID token permissions in both jobs.
 permissions:
   contents: read
-  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -50,11 +47,15 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+      # Cachix is a real binary cache (CDN-backed, shared across PRs, main,
+      # local dev, and end users) — replaces the CI-only GitHub Actions cache,
+      # whose slow Darwin uploads blew the 30-min job timeout. Fork PRs get no
+      # authToken and fall back to read-only pulls from the public cache.
+      - name: Enable Cachix
+        uses: cachix/cachix-action@v17
         with:
-          use-flakehub: disabled
-          use-gha-cache: enabled
+          name: modelsdev
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build Packages / ${{ matrix.os }}
         run: nix build .
       - name: Check Flake / ${{ matrix.os }}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,16 @@
 {
   description = "TUI and CLI for browsing AI models, benchmarks, and coding agents";
 
+  # CI pushes builds to this cache; users who accept the prompt download
+  # prebuilt binaries instead of compiling. The key is the cache's public
+  # signing key (verification only — safe to commit).
+  nixConfig = {
+    extra-substituters = [ "https://modelsdev.cachix.org" ];
+    extra-trusted-public-keys = [
+      "modelsdev.cachix.org-1:P/sJsc6wE55M7DWEGL7SjWAxKTD8TjZMYM8Iows77Ls="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";


### PR DESCRIPTION
## Summary
- Swap `magic-nix-cache-action` (GitHub Actions cache backend) for `cachix/cachix-action@v17` pushing to the public `modelsdev` cache
- Advertise the cache in `flake.nix` `nixConfig` (substituter + public signing key) so end users and local builds download prebuilt artifacts
- Drop the now-unneeded `id-token: write` permission (was for GHA-cache OIDC)

## Why
The GHA cache is CI-only and branch-scoped, so post-merge main runs rebuilt everything PR runs had already built; macOS cache uploads were slow enough to blow the 30-minute job timeout on main tonight, losing the write and guaranteeing a repeat rebuild. Cachix is one global CDN-backed pool (free for OSS, 5 GB).

## Test plan
- [ ] This PR's own Nix run populates the cache (first run = cold build + CDN upload on all 3 platforms)
- [ ] Cache hits visible in a subsequent run (post-merge main push should substitute instead of rebuild)
- [ ] macOS post/teardown drops from ~15+ min to minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)