### PR TITLE
fix: CLI --open/--closed weights filters + wire up display.default_tab

### DIFF
--- a/src/cli/benchmarks.rs
+++ b/src/cli/benchmarks.rs
@@ -775,18 +775,28 @@ fn run_show(model: &str, json: bool) -> Result<()> {
 ///
 /// AA is `SOURCES[0]`. The fetch runs on a one-shot blocking runtime so the CLI
 /// stays synchronous.
-//
-// TODO(phase-3): `ModelRow.open_weights` is `None` for AA here — the trait-based
-// openness enrichment is currently TUI-side only, so the `S` column renders an
-// em-dash. A later phase may call
-// `crate::benchmarks::apply_model_traits(&providers, &mut file.models)` here
-// (after `crate::api::fetch_providers()`) to populate it, matching the TUI.
+///
+/// The rows are then enriched from models.dev exactly like the TUI lane
+/// (`apply_model_traits`): this fills `open_weights` — without it the
+/// `--open`/`--closed` filters match nothing and the picker's O/C column is all
+/// em-dashes. models.dev being unreachable degrades to unenriched rows; the
+/// warning prints before any picker enters raw mode.
 fn load_benchmarks() -> Result<SourceFile> {
     let runtime = tokio::runtime::Runtime::new()?;
-    match runtime.block_on(fetch_source(&SOURCES[0])) {
-        Some(file) => Ok(file),
+    let mut file = match runtime.block_on(fetch_source(&SOURCES[0])) {
+        Some(file) => file,
         None => bail!("Failed to fetch benchmark data from the CDN"),
+    };
+    match crate::api::fetch_providers() {
+        Ok(providers_map) => {
+            let providers: Vec<_> = providers_map.into_iter().collect();
+            crate::benchmarks::apply_model_traits(&providers, &mut file.models);
+        }
+        Err(_) => eprintln!(
+            "warning: models.dev unreachable — open/closed weights and capability data unavailable"
+        ),
     }
+    Ok(file)
 }
 
 fn filter_entries<'a>(models: &'a [ModelRow], options: &ListOptions) -> Vec<&'a ModelRow> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -77,6 +77,18 @@ impl Tab {
             Tab::Status => Tab::Benchmarks,
         }
     }
+
+    /// Parse a config `display.default_tab` value. Case-insensitive; unknown
+    /// or missing values fall back to the default tab (Models).
+    pub fn from_config(value: Option<&str>) -> Self {
+        match value.map(str::to_ascii_lowercase).as_deref() {
+            Some("models") => Tab::Models,
+            Some("agents") => Tab::Agents,
+            Some("benchmarks") => Tab::Benchmarks,
+            Some("status") => Tab::Status,
+            _ => Tab::default(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -324,7 +336,7 @@ impl App {
             status_message: None,
             show_help: false,
             help_scroll: ScrollOffset::default(),
-            current_tab: Tab::default(),
+            current_tab: Tab::from_config(config.display.default_tab.as_deref()),
             models_app,
             agents_app,
             config,
@@ -1562,6 +1574,22 @@ mod tests {
     use std::ffi::OsString;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn tab_from_config_parses_known_values_case_insensitively() {
+        assert_eq!(Tab::from_config(Some("benchmarks")), Tab::Benchmarks);
+        assert_eq!(Tab::from_config(Some("Benchmarks")), Tab::Benchmarks);
+        assert_eq!(Tab::from_config(Some("STATUS")), Tab::Status);
+        assert_eq!(Tab::from_config(Some("agents")), Tab::Agents);
+        assert_eq!(Tab::from_config(Some("models")), Tab::Models);
+    }
+
+    #[test]
+    fn tab_from_config_falls_back_to_default_on_unknown_or_missing() {
+        assert_eq!(Tab::from_config(Some("benchmark")), Tab::default());
+        assert_eq!(Tab::from_config(Some("")), Tab::default());
+        assert_eq!(Tab::from_config(None), Tab::default());
+    }
 
     fn test_agent(name: &str, repo: &str) -> Agent {
         Agent {


### PR DESCRIPTION
Two fixes found during the post-merge documentation audit.

## CLI weights filters (bug)
`models benchmarks list --open/--closed` returned an empty list: the openness enrichment was TUI-only (`TODO(phase-3)`), so `open_weights` was `None` on every CLI row and the filter rejected all of them. `load_benchmarks` now runs the same `apply_model_traits` models.dev pass as the TUI. Side benefit: the CLI picker's O/C column populates instead of rendering all em-dashes. models.dev unreachable → unenriched rows + a warning (printed before raw mode).

Live-verified: `--open` returns open-weights rows, `--closed --json` shows `open_weights: false` rows.

## display.default_tab (dead config, now wired)
Declared since config support landed, documented in the wiki, consumed by nothing. `Tab::from_config` parses it case-insensitively (`models`/`agents`/`benchmarks`/`status`); unknown/missing falls back to Models. Live-verified in tmux: `default_tab = "benchmarks"` launches straight into the Benchmarks tab.

## Test plan
- [x] `mise run fmt && mise run clippy && mise run test` (418 + 137, two new tests for the Tab parser)
- [x] Live CLI verification of both filters against the CDN + models.dev
- [x] Live TUI verification of default_tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)