### PR TITLE
chore: release v0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "modelsdev"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsdev"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 # The `transform` [[bin]] makes bare `cargo run` ambiguous without this.
 default-run = "models"


### PR DESCRIPTION
Patch release to ship the multi-host benchmark-fetch fallback chain (#45) to users.

`fetch_source` now tries `cdn.jsdelivr.net@main` → `fastly.jsdelivr.net@main` → `raw.githubusercontent.com/.../main/...`, so a jsDelivr branch-resolution outage (like 2026-06-16) no longer takes the benchmarks tab down. The fix is compiled into the binary, so it only reaches users via a new release.

- `Cargo.toml` `0.12.1` → `0.12.2`, `Cargo.lock` updated in the same commit.
- No functional change beyond what's already on `main` (#45, #46).

After merge, push the `v0.12.2` tag to trigger the release workflow (crates.io / .deb / .rpm / AUR / GitHub flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)