### PR TITLE
chore: release v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "modelsdev"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsdev"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 # The `transform` [[bin]] makes bare `cargo run` ambiguous without this.
 default-run = "models"


### PR DESCRIPTION
Patch release bundling the two bug fixes from #48 (now that they're on `main`) into a versioned binary, plus the lockfile bump.

## What ships in v0.12.3
- **Agents tab — latest changelog on launch.** The startup cache-priming loop no longer marks tracked entries `Loaded`, which had caused `spawn_agent_fetches` to skip the background fetch. The fetch now fires on launch and revalidates (stale-while-revalidate), so you no longer need to press `R` to see the newest changelog.
- **Benchmarks — honest freshness label.** The source-bar indicator now reads `updated {relative}` instead of `fetched {relative}`. The timestamp is the data's build-time last-change, not the client fetch time (the app always fetches fresh per launch).
- **CI — hardened jsDelivr purge** (already live on `main` via #48; included here for completeness). Retry/backoff around the purge endpoint's intermittent `no available server` 200 responses.

## Release mechanics
Version bumped in `Cargo.toml` + `Cargo.lock` (`0.12.2 → 0.12.3`). After this merges and CI is green, I'll tag `v0.12.3` on `main` and push the tag to trigger the release workflow (binaries, .deb/.rpm, crates.io, AUR).

## Verification
`mise run fmt && mise run clippy && mise run test` — clippy clean (`-D warnings`), 137 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)